### PR TITLE
Keep statements separate for parsing

### DIFF
--- a/retrieval/vector_search.py
+++ b/retrieval/vector_search.py
@@ -23,12 +23,30 @@ def load_policy_index():
     return (index, chunks)
 
 
+def _combined_excerpt(claim_struct: dict) -> str:
+    """Return text snippet for embedding search from various claim formats."""
+
+    if "raw_excerpt" in claim_struct:
+        return claim_struct["raw_excerpt"][:1000]
+
+    parts = []
+    provider = claim_struct.get("provider_statement", {})
+    medical_aid = claim_struct.get("medical_aid_statement", {})
+    if isinstance(provider, dict) and provider.get("raw_excerpt"):
+        parts.append(provider["raw_excerpt"])
+    if isinstance(medical_aid, dict) and medical_aid.get("raw_excerpt"):
+        parts.append(medical_aid["raw_excerpt"])
+
+    return "\n".join(parts)[:1000]
+
+
 def retrieve_rules(index_tuple, claim_struct, k: int = 5):
     index, chunks = index_tuple
     client = get_client()
     emb = (
         client.embeddings.create(
-            input=[claim_struct["raw_excerpt"][:1000]], model="text-embedding-3-large"
+            input=[_combined_excerpt(claim_struct)],
+            model="text-embedding-3-large",
         )
         .data[0]
         .embedding


### PR DESCRIPTION
## Summary
- improve variable naming in `app.py`
- parse medical aid and provider statements separately
- combine statement excerpts flexibly when retrieving rules

## Testing
- `python -m py_compile app.py retrieval/vector_search.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852782a5f3483339bef72f8527cb4a8