### PR TITLE
Add image support in OCR workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ make embed
 
 This will process `data/static/policy_rules.pdf` and save the FAISS index in `embeddings/`.
 
+You can also OCR standalone PDFs or images using the general helper in `ocr`:
+
+```python
+from ocr import extract_text
+
+text = extract_text("my_scan.png")
+```
+
 ---
 
 ### ▶️ Run the backend API
@@ -43,11 +51,11 @@ Starts a FastAPI server on `http://localhost:8000` that exposes a single `/asses
 make run-frontend
 ```
 
-Launches the React based UI where you can upload PDF documents and view the assessment results.
+Launches the React based UI where you can upload PDF or image documents and view the assessment results.
 
-### Upload PDFs
+### Upload Documents
 
-The app requires three PDFs:
+The app requires three files (PDF or image):
 
 1. Medical Scheme Statement
 2. Provider Invoice

--- a/backend/main.py
+++ b/backend/main.py
@@ -7,7 +7,7 @@ from fastapi import FastAPI, File, HTTPException, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 
 from assessment.assessor import assess_claim
-from ocr.pdf_reader import extract_text_from_pdf
+from ocr import extract_text
 from parsing.claim_form_ai import ai_extract
 from parsing.statement_parser import parse_statement
 from retrieval.vector_search import load_policy_index, retrieve_rules
@@ -43,9 +43,9 @@ async def assess_claim_endpoint(
     claim: UploadFile = File(...),
 ):
     try:
-        medical_text = extract_text_from_pdf(io.BytesIO(await medical.read()))
-        provider_text = extract_text_from_pdf(io.BytesIO(await provider.read()))
-        claim_text = extract_text_from_pdf(io.BytesIO(await claim.read()))
+        medical_text = extract_text(io.BytesIO(await medical.read()))
+        provider_text = extract_text(io.BytesIO(await provider.read()))
+        claim_text = extract_text(io.BytesIO(await claim.read()))
 
         medical_data = parse_statement(medical_text)
         provider_data = parse_statement(provider_text)

--- a/embeddings/embed_policy.py
+++ b/embeddings/embed_policy.py
@@ -16,7 +16,7 @@ import numpy as np
 import yaml
 
 from config.openai_config import get_client
-from ocr.pdf_reader import extract_text_from_pdf
+from ocr import extract_text
 from utils.text_utils import chunk_text
 
 INDEX_PATH = os.path.join(os.path.dirname(__file__), "policy_index.faiss")
@@ -44,7 +44,7 @@ def build_index(path: str):
     if ext in {".yml", ".yaml"}:
         chunks = load_yaml_as_chunks(path)
     elif ext == ".pdf":
-        text = extract_text_from_pdf(path)
+        text = extract_text(path)
         chunks = chunk_text(text)
     else:
         raise ValueError("Unsupported file type. Use .pdf, .yml, or .yaml")

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -62,10 +62,10 @@ export default function Home() {
         onDragOver={(e) => handleDrag(e, fileType)}
         onDrop={(e) => handleDrop(e, setter)}
       >
-        <input 
-          className="file-input-hidden" 
-          type="file" 
-          accept="application/pdf" 
+        <input
+          className="file-input-hidden"
+          type="file"
+          accept=".pdf,image/*"
           onChange={e => setter(e.target.files[0])}
           id={`file-${fileType}`}
         />
@@ -170,7 +170,7 @@ export default function Home() {
               file={medical}
               setter={setMedical}
               label="Medical Scheme Statement"
-              description="Upload your medical scheme statement PDF"
+              description="Upload your medical scheme statement (PDF or image)"
               fileType="medical"
               icon={<DocumentIcon />}
             />
@@ -179,7 +179,7 @@ export default function Home() {
               file={provider}
               setter={setProvider}
               label="Provider Invoice"
-              description="Upload the healthcare provider invoice PDF"
+              description="Upload the healthcare provider invoice (PDF or image)"
               fileType="provider"
               icon={<InvoiceIcon />}
             />
@@ -188,7 +188,7 @@ export default function Home() {
               file={claim}
               setter={setClaim}
               label="Claim Form"
-              description="Upload the completed GapCover claim form PDF"
+              description="Upload the completed GapCover claim form (PDF or image)"
               fileType="claim"
               icon={<ClipboardIcon />}
             />

--- a/ocr/__init__.py
+++ b/ocr/__init__.py
@@ -1,0 +1,4 @@
+from .document_reader import extract_text, extract_text_from_pdf
+from .image_reader import extract_text_from_image
+
+__all__ = ["extract_text", "extract_text_from_pdf", "extract_text_from_image"]

--- a/ocr/document_reader.py
+++ b/ocr/document_reader.py
@@ -1,8 +1,10 @@
 import io
+import os
 
 import fitz
 import pytesseract
 from PIL import Image
+from .image_reader import extract_text_from_image
 
 
 def extract_text_from_pdf(file_obj_or_path):
@@ -23,3 +25,17 @@ def extract_text_from_pdf(file_obj_or_path):
             txt = pytesseract.image_to_string(img)
         full_text += txt + "\n"
     return full_text
+
+
+def extract_text(file_obj_or_path):
+    """Extract text from a PDF or image by auto-detecting the file type."""
+    if hasattr(file_obj_or_path, "read"):
+        buf = file_obj_or_path.read()
+        if buf[:4] == b"%PDF":
+            return extract_text_from_pdf(io.BytesIO(buf))
+        return extract_text_from_image(io.BytesIO(buf))
+
+    ext = os.path.splitext(str(file_obj_or_path))[1].lower()
+    if ext == ".pdf":
+        return extract_text_from_pdf(file_obj_or_path)
+    return extract_text_from_image(file_obj_or_path)

--- a/ocr/image_reader.py
+++ b/ocr/image_reader.py
@@ -1,0 +1,12 @@
+import io
+from PIL import Image
+import pytesseract
+
+
+def extract_text_from_image(file_obj_or_path):
+    """Extract text from an image file or file-like object using Tesseract OCR."""
+    if hasattr(file_obj_or_path, "read"):
+        img = Image.open(io.BytesIO(file_obj_or_path.read()))
+    else:
+        img = Image.open(file_obj_or_path)
+    return pytesseract.image_to_string(img)


### PR DESCRIPTION
## Summary
- rename `pdf_reader` to `document_reader` and add `extract_text` helper
- re-export `extract_text` from the `ocr` package
- switch backend and embedding scripts to use the unified helper
- accept images in the frontend upload boxes
- document the new behaviour in the README

## Testing
- `python3 -m py_compile ocr/document_reader.py ocr/image_reader.py ocr/__init__.py backend/main.py embeddings/embed_policy.py`


------
https://chatgpt.com/codex/tasks/task_e_68531ac51c34833382d8b0e75f3084f6